### PR TITLE
Webpack-babel icon

### DIFF
--- a/config/icons/filename.json
+++ b/config/icons/filename.json
@@ -14,6 +14,7 @@
     "favicon.ico": "favicon",
     "nginx.conf": "nginx",
     "webpack.config.js": "webpack",
+    "webpack.config.babel.js": "webpack",
     "_vimrc": "vim",
     "_viminfo": "vim"
 }


### PR DESCRIPTION
Basically created an alias for webpack.config.js to support babel syntax.
